### PR TITLE
Load Inngest function modules from path

### DIFF
--- a/dev.exs
+++ b/dev.exs
@@ -28,7 +28,7 @@ defmodule Inngest.Dev.Router do
     |> send_resp(200, data)
   end
 
-  inngest("/api/inngest", funcs: [EventFn, CronFn])
+  inngest("/api/inngest", path: "dev/**")
 
   match _ do
     send_resp(conn, 404, "oops\n")

--- a/dev/event.ex
+++ b/dev/event.ex
@@ -37,9 +37,3 @@ defmodule Inngest.Dev.EventFn do
     {:ok, data}
   end
 end
-
-defmodule Inngest.Dev.CronFn do
-  use Inngest.Function,
-    name: "test cron",
-    cron: "TZ=America/Los_Angeles * * * * *"
-end

--- a/dev/scheduled/cron.ex
+++ b/dev/scheduled/cron.ex
@@ -1,0 +1,5 @@
+defmodule Inngest.Dev.CronFn do
+  use Inngest.Function,
+    name: "test cron",
+    cron: "TZ=America/Los_Angeles * * * * *"
+end

--- a/lib/inngest/router/helper.ex
+++ b/lib/inngest/router/helper.ex
@@ -11,4 +11,30 @@ defmodule Inngest.Router.Helper do
       Map.put(x, slug, func.serve(path))
     end)
   end
+
+  def load_functions_from_path(%{path: paths} = kv) when is_list(paths) do
+    {:ok, modules, _warnings} =
+      paths
+      |> Enum.map(&Path.wildcard/1)
+      |> List.flatten()
+      |> Stream.filter(&(!File.dir?(&1)))
+      |> Enum.uniq()
+      |> Kernel.ParallelCompiler.compile()
+
+    funcs = Map.get(kv, :funcs, [])
+    Map.put(kv, :funcs, funcs ++ modules)
+  end
+
+  def load_functions_from_path(%{path: path} = kv) when is_binary(path) do
+    {:ok, modules, _warnings} =
+      path
+      |> Path.wildcard()
+      |> Enum.filter(&(!File.dir?(&1)))
+      |> Kernel.ParallelCompiler.compile()
+
+    funcs = Map.get(kv, :funcs, [])
+    Map.put(kv, :funcs, funcs ++ modules)
+  end
+
+  def load_functions_from_path(kv), do: kv
 end

--- a/lib/inngest/router/helper.ex
+++ b/lib/inngest/router/helper.ex
@@ -2,6 +2,7 @@ defmodule Inngest.Router.Helper do
   @moduledoc """
   Helper module for router and plugs
   """
+  @conflict_opt :ignore_module_conflict
 
   @spec func_map(binary(), list()) :: map()
   def func_map(path, funcs) do
@@ -12,7 +13,11 @@ defmodule Inngest.Router.Helper do
     end)
   end
 
+  @spec load_functions_from_path(map()) :: map()
   def load_functions_from_path(%{path: paths} = kv) when is_list(paths) do
+    ignored = Code.get_compiler_option(@conflict_opt)
+    unless ignored, do: Code.put_compiler_option(@conflict_opt, true)
+
     {:ok, modules, _warnings} =
       paths
       |> Enum.map(&Path.wildcard/1)
@@ -21,16 +26,23 @@ defmodule Inngest.Router.Helper do
       |> Enum.uniq()
       |> Kernel.ParallelCompiler.compile()
 
+    unless ignored, do: :ok = Code.put_compiler_option(@conflict_opt, false)
+
     funcs = Map.get(kv, :funcs, [])
     Map.put(kv, :funcs, funcs ++ modules)
   end
 
   def load_functions_from_path(%{path: path} = kv) when is_binary(path) do
+    ignored = Code.get_compiler_option(@conflict_opt)
+    unless ignored, do: Code.put_compiler_option(@conflict_opt, true)
+
     {:ok, modules, _warnings} =
       path
       |> Path.wildcard()
       |> Enum.filter(&(!File.dir?(&1)))
       |> Kernel.ParallelCompiler.compile()
+
+    unless ignored, do: :ok = Code.put_compiler_option(@conflict_opt, false)
 
     funcs = Map.get(kv, :funcs, [])
     Map.put(kv, :funcs, funcs ++ modules)

--- a/lib/inngest/router/phoenix.ex
+++ b/lib/inngest/router/phoenix.ex
@@ -18,6 +18,7 @@ defmodule Inngest.Router.Phoenix do
         opts
       end
       |> Enum.into(%{})
+      |> Inngest.Router.Helper.load_functions_from_path()
       |> Map.put(:framework, @framework)
       |> Macro.escape()
 

--- a/lib/inngest/router/plug.ex
+++ b/lib/inngest/router/plug.ex
@@ -18,6 +18,7 @@ defmodule Inngest.Router.Plug do
         opts
       end
       |> Enum.into(%{})
+      |> Inngest.Router.Helper.load_functions_from_path()
       |> Map.put(:framework, @framework)
       |> Macro.escape()
 

--- a/lib/inngest/router/register.ex
+++ b/lib/inngest/router/register.ex
@@ -42,7 +42,7 @@ defmodule Inngest.Router.Register do
     |> send_resp(status, resp)
   end
 
-  defp register(path, functions, opts \\ []) do
+  defp register(path, functions, opts) do
     framework = Keyword.get(opts, :framework)
 
     payload = %{

--- a/test/inngest/router/helper_test.exs
+++ b/test/inngest/router/helper_test.exs
@@ -29,4 +29,36 @@ defmodule Inngest.Router.HelperTest do
              } = Helper.func_map(path, funcs)
     end
   end
+
+  describe "load_functions_from_path/1" do
+    @path "test/support/**/*.ex"
+    @paths ["dev/**/*.ex", @path]
+
+    @dev_mods [Inngest.Dev.EventFn, Inngest.Dev.CronFn]
+    @test_mods [Inngest.TestEventFn, Inngest.TestCronFn]
+
+    test "should compile all modules in the provided path" do
+      assert %{funcs: funcs} = Helper.load_functions_from_path(%{path: @path})
+      assert Enum.count(funcs) == Enum.count(@test_mods)
+
+      for mod <- funcs do
+        assert Enum.member?(@test_mods, mod)
+      end
+    end
+
+    test "should compile all modules in the provided paths" do
+      expected = @dev_mods ++ @test_mods
+
+      assert %{funcs: funcs} = Helper.load_functions_from_path(%{path: @paths})
+      assert Enum.count(funcs) == Enum.count(expected)
+
+      for mod <- funcs do
+        assert Enum.member?(expected, mod)
+      end
+    end
+
+    test "should not update the map if path is not provided" do
+      assert %{funcs: [10]} = Helper.load_functions_from_path(%{funcs: [10]})
+    end
+  end
 end


### PR DESCRIPTION
resolves #20 

Provides a easier way to get modules registered with the `inngest` macro so users don't have to manually provide a list of modules.