### PR TITLE
fix compile errors due to parallel compilation conflicts

### DIFF
--- a/lib/inngest/router/helper.ex
+++ b/lib/inngest/router/helper.ex
@@ -1,8 +1,6 @@
 defmodule Inngest.Router.Helper do
   @moduledoc false
 
-  @conflict_opt :ignore_module_conflict
-
   @spec func_map(binary(), list()) :: map()
   def func_map(path, funcs) do
     funcs
@@ -14,38 +12,45 @@ defmodule Inngest.Router.Helper do
 
   @spec load_functions_from_path(map()) :: map()
   def load_functions_from_path(%{path: paths} = kv) when is_list(paths) do
-    ignored = Code.get_compiler_option(@conflict_opt)
-    unless ignored, do: Code.put_compiler_option(@conflict_opt, true)
-
-    {:ok, modules, _warnings} =
+    modules =
       paths
       |> Enum.map(&Path.wildcard/1)
       |> List.flatten()
       |> Stream.filter(&(!File.dir?(&1)))
       |> Enum.uniq()
-      |> Kernel.ParallelCompiler.compile()
-
-    unless ignored, do: :ok = Code.put_compiler_option(@conflict_opt, false)
+      |> extract_modules()
 
     funcs = Map.get(kv, :funcs, [])
     Map.put(kv, :funcs, funcs ++ modules)
   end
 
   def load_functions_from_path(%{path: path} = kv) when is_binary(path) do
-    ignored = Code.get_compiler_option(@conflict_opt)
-    unless ignored, do: Code.put_compiler_option(@conflict_opt, true)
-
-    {:ok, modules, _warnings} =
+    modules =
       path
       |> Path.wildcard()
       |> Enum.filter(&(!File.dir?(&1)))
-      |> Kernel.ParallelCompiler.compile()
-
-    unless ignored, do: :ok = Code.put_compiler_option(@conflict_opt, false)
+      |> extract_modules()
 
     funcs = Map.get(kv, :funcs, [])
     Map.put(kv, :funcs, funcs ++ modules)
   end
 
   def load_functions_from_path(kv), do: kv
+
+  defp extract_modules(files) do
+    files
+    |> Enum.flat_map(fn file ->
+      with {:ok, content} <- File.read(file),
+           {:ok, ast} = Code.string_to_quoted(content) do
+        module_names(ast)
+      else
+        _ -> []
+      end
+    end)
+  end
+
+  defp module_names({:__block__, _, mods}), do: Enum.flat_map(mods, &module_names/1)
+
+  defp module_names({:defmodule, _line, [{_, _, module}, _body]}),
+    do: [Module.concat(module)]
 end

--- a/lib/inngest/router/helper.ex
+++ b/lib/inngest/router/helper.ex
@@ -41,7 +41,7 @@ defmodule Inngest.Router.Helper do
     files
     |> Enum.flat_map(fn file ->
       with {:ok, content} <- File.read(file),
-           {:ok, ast} = Code.string_to_quoted(content) do
+           {:ok, ast} <- Code.string_to_quoted(content) do
         module_names(ast)
       else
         _ -> []

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Inngest.MixProject do
   use Mix.Project
 
-  @version "0.1.2"
+  @version "0.1.3"
 
   def project do
     [


### PR DESCRIPTION
When attempting to compile files from the given path, the lib will fail to compile due to compilation race conditions.

Change module loading to loading into AST, and extracting from there instead.