### PR TITLE
runtime path evaluation for Phoenix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+### Documentation
+
+- Docs: add `path_runtime_eval` reference for config
+
 ### Features
 
 - Feat: allow runtime path evaluation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [unreleased]
+
+### Features
+
+- Feat: allow runtime path evaluation
+
 ## [0.1.4] - 2023-07-28
 
 ### Miscellaneous Tasks

--- a/config/config.exs
+++ b/config/config.exs
@@ -6,4 +6,5 @@ config :elixir, :time_zone_database, Tz.TimeZoneDatabase
 config :tesla, adapter: {Tesla.Adapter.Hackney, [recv_timeout: 10_000]}
 
 config :inngest,
-  env: :dev
+  env: :dev,
+  path_runtime_eval: true

--- a/docs/references/config.md
+++ b/docs/references/config.md
@@ -97,3 +97,17 @@ It's not required for the Dev Server but required for Inngest Cloud.
 ``` elixir
 config :inngest, signing_key: "key"
 ```
+
+### Path runtime evaluation
+
+Default value: `false`
+
+When [passing a `path` to `inngest`](serve-api.html) macro in your router, this enables the functions
+to be evaluated during runtime instead of compile time, which is the default.
+
+This exists for the sore purpose of easing development feedback, and should not be
+used for non development workloads.
+
+``` elixir
+config :inngest, path_runtime_eval: true
+```

--- a/lib/inngest/config.ex
+++ b/lib/inngest/config.ex
@@ -41,9 +41,6 @@ defmodule Inngest.Config do
     end
   end
 
-  @spec is_dev() :: boolean()
-  def is_dev(), do: env() == :dev
-
   @spec event_url() :: binary()
   def event_url() do
     with nil <- System.get_env("INNGEST_EVENT_URL"),
@@ -102,6 +99,12 @@ defmodule Inngest.Config do
       key -> key
     end
   end
+
+  @spec is_dev() :: boolean()
+  def is_dev(), do: env() == :dev
+
+  @spec path_runtime_eval() :: boolean()
+  def path_runtime_eval(), do: Application.get_env(:inngest, :path_runtime_eval, false)
 
   @spec version() :: binary()
   def version(), do: Application.spec(:inngest, :vsn)

--- a/lib/inngest/router/invoke.ex
+++ b/lib/inngest/router/invoke.ex
@@ -13,9 +13,13 @@ defmodule Inngest.Router.Invoke do
 
   defp exec(
          %{request_path: path, private: %{raw_body: [body]}} = conn,
-         %{"event" => event, "ctx" => ctx, "fnId" => fn_slug, funcs: funcs} = params
+         %{"event" => event, "ctx" => ctx, "fnId" => fn_slug} = params
        ) do
-    funcs = func_map(path, funcs)
+    funcs =
+      params
+      |> load_functions()
+      |> func_map(path)
+
     args = %{ctx: ctx, event: event, fn_slug: fn_slug, funcs: funcs, params: params}
 
     {status, payload} =

--- a/lib/inngest/router/register.ex
+++ b/lib/inngest/router/register.ex
@@ -17,9 +17,12 @@ defmodule Inngest.Router.Register do
 
   defp exec(
          %{request_path: path} = conn,
-         %{funcs: funcs, framework: framework} = _params
+         %{framework: framework} = params
        ) do
-    funcs = func_map(path, funcs)
+    funcs =
+      params
+      |> load_functions()
+      |> func_map(path)
 
     {status, resp} =
       case register(path, funcs, framework: framework) do

--- a/test/inngest/router/helper_test.exs
+++ b/test/inngest/router/helper_test.exs
@@ -26,7 +26,7 @@ defmodule Inngest.Router.HelperTest do
                    }
                  ]
                }
-             } = Helper.func_map(path, funcs)
+             } = Helper.func_map(funcs, path)
     end
   end
 


### PR DESCRIPTION
Without this, local development will also not pick up the changes.
This setting should only be used for development